### PR TITLE
feat(ci): Remove build step from github workflows

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -6,20 +6,7 @@ env:
   ENVIRONMENT: dev
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: "package.json"
-      - run: npm version
-      - uses: ./.github/actions/cached-npm-install
-      - run: npm run build
-
   unit-test:
-    needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,21 +10,8 @@ env:
   ENVIRONMENT: prod
 
 jobs:
-  build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: "package.json"
-      - run: npm version
-      - uses: ./.github/actions/cached-npm-install
-      - run: npm run build
-
   unit-test:
-    needs: [build]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -10,21 +10,8 @@ env:
   ENVIRONMENT: stage
 
 jobs:
-  build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: "package.json"
-      - run: npm version
-      - uses: ./.github/actions/cached-npm-install
-      - run: npm run build
-
   unit-test:
-    needs: [build]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Background

Further to some work that was done in the cuckoo graph, this removes the build step of each of the deployment github work flows. Each subsequent step already performs these actions, and the build step doesn't produce any specific artefacts that are needed later on. 

## Changes

- Remove build step from workflow ymls
