### PR TITLE
fix(linting): Don't lint .md files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*.{js,ts,json,yml,md}": "npm run lint"
+  "*.{js,ts,json,yml}": "npm run lint"
 }


### PR DESCRIPTION
## Background
Eslint doesn't like linting md files, so we shouldn't ask it to.