### PR TITLE
feat(linting): add prettier as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "lerna": "6.6.2",
         "lint-staged": "13.2.2",
         "mocked-env": "1.3.5",
+        "prettier": "3.2.4",
         "rimraf": "5.0.1",
         "ts-jest": "29.1.0",
         "ts-node": "10.9.1",
@@ -13691,6 +13692,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
@@ -26663,6 +26679,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lerna": "6.6.2",
     "lint-staged": "13.2.2",
     "mocked-env": "1.3.5",
+    "prettier": "3.2.4",
     "rimraf": "5.0.1",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",


### PR DESCRIPTION
Background
Add prettier to all BE projects as some pre-commit hooks depend on it - previously came from XO

