### PR TITLE
fix: Update Node/npm version in package templates

### DIFF
--- a/_templates/cdk-package/new/package-json.ejs.t
+++ b/_templates/cdk-package/new/package-json.ejs.t
@@ -7,8 +7,8 @@ to: packages/<%= packageName %>/package.json
   "license": "UNLICENSED",
   "version": "0.1.0",
   "engines": {
-    "node": "^18.14.0",
-    "npm": "9.x"
+    "node": "^18.19.0",
+    "npm": "10.x"
   },
   "scripts": {
     "build": "tsc",

--- a/_templates/graphql/new/package/package-json.ejs.t
+++ b/_templates/graphql/new/package/package-json.ejs.t
@@ -8,8 +8,8 @@ unless_exists: true
   "license": "UNLICENSED",
   "version": "0.1.0",
   "engines": {
-    "node": "^18.14.0",
-    "npm": "9.x"
+    "node": "^18.19.0",
+    "npm": "10.x"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Background

Bumps the Node.js/npm versions present in the templated package.jsons so they match what is in the root.
